### PR TITLE
Explicit field values

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,24 @@ Blog.get_article_by_id(
 )
 ```
 
+## Special Considerations
+
+With the auto-binding functionality offered by Query Builder, you can specify field comparisons in queries using the special atom value syntax: `:<field_name>@self`. This way Query Builder understands the intent is to compare fields vs a raw value.  For example:
+
+```elixir
+users_where_name_matches_nickname =
+  User
+  |> QueryBuilder.where({:name, :eq, :nickname@self})
+  |> Repo.all()
+```
+
+would resolve to a query along the following form:
+
+```sql
+select * from users where users.name = users.nickname
+```
+
+
 ## Installation
 
 Add `query_builder` for Elixir as a dependency in your `mix.exs` file:

--- a/lib/query/where.ex
+++ b/lib/query/where.ex
@@ -193,19 +193,22 @@ defmodule QueryBuilder.Query.Where do
         end
     end
   end
+
   defp value_is_field(val) when val in [nil, false, true], do: false
 
-  defp value_is_field(val) when is_atom(val) do
-    val |> Atom.to_string() |> String.ends_with?(@value_is_field_marker)
+  defp value_is_field(val) do
+    val |> to_string() |> String.ends_with?(@value_is_field_marker)
   end
 
-  defp value_is_field(_), do: false
-
-  defp referenced_field_in_value(val) when is_atom(val) do
-    str_val = Atom.to_string(val)
+  defp referenced_field_in_value(val) do
+    str_val = to_string(val)
 
     str_val
     |> binary_part(0, byte_size(str_val) - byte_size(@value_is_field_marker))
-    |> String.to_atom()
+
+    # Fields are usually represented as atoms, but we convert to strings later
+    # in parsing the query anyway @see &QueryBuilder.Utils.find_field_and_binding_from_token/3
+    # No need for atom conversion
+    # |> String.to_existing_atom()
   end
 end

--- a/lib/query/where.ex
+++ b/lib/query/where.ex
@@ -4,6 +4,8 @@ defmodule QueryBuilder.Query.Where do
   require Ecto.Query
   import QueryBuilder.Utils
 
+  @value_is_field_marker "@self"
+
   def where(ecto_query, assoc_list, filters, or_filters) do
     dynamic_query = build_dynamic_query(ecto_query, assoc_list, filters, or_filters)
 
@@ -36,16 +38,22 @@ defmodule QueryBuilder.Query.Where do
     apply_filter(query, assoc_list, {field, operator, value, []})
   end
 
-  defp apply_filter(query, assoc_list, {field1, operator, field2, operator_opts})
-       when is_atom(field2) and field2 not in [nil, false, true] do
-    {field1, binding_field1} = find_field_and_binding_from_token(query, assoc_list, field1)
-    {field2, binding_field2} = find_field_and_binding_from_token(query, assoc_list, field2)
+  defp apply_filter(query, assoc_list, {field, operator, value, operator_opts})
+       when is_atom(value) do
+    {field, binding_field1} = find_field_and_binding_from_token(query, assoc_list, field)
 
-    do_where(
-      binding_field1,
-      binding_field2,
-      {field1, operator, field2, operator_opts}
-    )
+    if value_is_field(value) do
+      field2 = referenced_field_in_value(value)
+      {field2, binding_field2} = find_field_and_binding_from_token(query, assoc_list, field2)
+
+      do_where(
+        binding_field1,
+        binding_field2,
+        {field, operator, field2, operator_opts}
+      )
+    else
+      do_where(binding_field1, {field, operator, value, operator_opts})
+    end
   end
 
   defp apply_filter(query, assoc_list, {field, operator, value, operator_opts}) do
@@ -184,5 +192,20 @@ defmodule QueryBuilder.Query.Where do
             Ecto.Query.dynamic([{^b1, x}, {^b2, y}], fragment("? ilike concat('%', ?, '%')", field(x, ^f1), field(y, ^f2)))
         end
     end
+  end
+  defp value_is_field(val) when val in [nil, false, true], do: false
+
+  defp value_is_field(val) when is_atom(val) do
+    val |> Atom.to_string() |> String.ends_with?(@value_is_field_marker)
+  end
+
+  defp value_is_field(_), do: false
+
+  defp referenced_field_in_value(val) when is_atom(val) do
+    str_val = Atom.to_string(val)
+
+    str_val
+    |> binary_part(0, byte_size(str_val) - byte_size(@value_is_field_marker))
+    |> String.to_atom()
   end
 end

--- a/test/query_builder_test.exs
+++ b/test/query_builder_test.exs
@@ -346,21 +346,28 @@ defmodule QueryBuilderTest do
   test "where comparing two fields" do
     users_where_name_matches_nickname =
       User
-      |> QueryBuilder.where({:name, :eq, :nickname})
+      |> QueryBuilder.where({:name, :eq, :nickname@self})
       |> Repo.all()
 
     assert 4 == length(users_where_name_matches_nickname)
 
+    users_where_name_matches_raw_nickname =
+      User
+      |> QueryBuilder.where({:name, :eq, :nickname})
+      |> Repo.all()
+
+    assert 0 == length(users_where_name_matches_raw_nickname)
+
     users_where_name_included_in_email =
       User
-      |> QueryBuilder.where({:email, :contains, :name, case: :insensitive})
+      |> QueryBuilder.where({:email, :contains, :name@self, case: :insensitive})
       |> Repo.all()
 
     assert 6 == length(users_where_name_included_in_email)
 
     users_where_name_included_in_email =
       User
-      |> QueryBuilder.where({:email, :starts_with, :name, case: :insensitive})
+      |> QueryBuilder.where({:email, :starts_with, :name@self, case: :insensitive})
       |> Repo.all()
 
     assert 5 == length(users_where_name_included_in_email)

--- a/test/support/a_or_b.ex
+++ b/test/support/a_or_b.ex
@@ -1,0 +1,21 @@
+defmodule QueryBuilder.AorB do
+  @moduledoc false
+
+  use Ecto.Type
+
+  @impl true
+  def type, do: :string
+
+  @impl true
+  def cast(str) when is_binary(str), do: {:ok, str}
+  def cast(atm) when is_atom(atm), do: {:ok, Atom.to_string(atm)}
+  def cast(_), do: :error
+
+  @impl true
+  def load(str) when is_binary(str), do: {:ok, str}
+  def load(_), do: :error
+
+  @impl true
+  def dump(str) when is_binary(str), do: {:ok, str}
+  def dump(_), do: :error
+end

--- a/test/support/models/user.ex
+++ b/test/support/models/user.ex
@@ -3,7 +3,7 @@ defmodule QueryBuilder.User do
   use Ecto.Schema
 
   schema "users" do
-    field(:name, :string)
+    field(:name, QueryBuilder.AorB)
     field(:email, :string)
     field(:nickname, :string)
     field(:deleted, :boolean)


### PR DESCRIPTION
Differentiates atom values from schema fields by introducing special syntax to specify field values vs raw values.  This addresses https://github.com/mathieuprog/query_builder/issues/2